### PR TITLE
Init sphinx docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/
 *.so
 _bspl.*.pyd
 _bspl.c
+docs/auto_*

--- a/benchmarks/1d-benchmark.py
+++ b/benchmarks/1d-benchmark.py
@@ -1,3 +1,9 @@
+"""
+==================================
+1D ndsplines vs. scipy.interpolate
+==================================
+"""
+
 import numpy as np
 import gc
 import time
@@ -14,7 +20,7 @@ n_iter = 10
 def timeit(func, n_iter=1, return_samps=True, **func_kwargs):
     results = np.empty(n_iter, dtype=np.double)
     for i in range(n_iter):
-        gc.collect()
+        # gc.collect()
 
         tstart = time.time()
         func(**func_kwargs)

--- a/benchmarks/1d-profile.py
+++ b/benchmarks/1d-profile.py
@@ -1,3 +1,10 @@
+"""
+=====================================
+1-Dimensional Interpolation Profiling
+=====================================
+"""
+
+
 from scipy import interpolate
 import numpy as np
 import ndsplines

--- a/benchmarks/1d-profile.py
+++ b/benchmarks/1d-profile.py
@@ -4,7 +4,6 @@
 =====================================
 """
 
-
 from scipy import interpolate
 import numpy as np
 import ndsplines

--- a/benchmarks/README.txt
+++ b/benchmarks/README.txt
@@ -1,0 +1,5 @@
+==========
+Benchmarks
+==========
+
+Scripts for benchmarking ndsplines.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,24 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf "$(BUILDDIR)"
+	rm -rf auto_*/
+
+
+.PHONY: help clean Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,7 @@
+===
+API
+===
+
+.. automodule:: ndsplines
+    :members:
+    :special-members: __call__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,75 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+import ndsplines
+
+# -- Project information -----------------------------------------------------
+
+project = 'ndsplines'
+copyright = '2019, Benjamin Margolis'
+author = 'Benjamin Margolis'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.mathjax',
+    'sphinx_gallery.gen_gallery',
+    # can enable this later if we want
+    # 'sphinx.ext.autosummary',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+
+# sphinx-gallery configuration
+# see https://sphinx-gallery.github.io/configuration.html
+sphinx_gallery_conf = {
+    'examples_dirs': ['../examples', '../benchmarks'],
+    'gallery_dirs': ['auto_examples', 'auto_benchmarks'],
+    'filename_pattern': r'.*\.py',
+    'line_numbers': True,
+    'download_all_examples': False,
+}
+
+
+# autosummary_generate = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,12 @@
+=========
+ndsplines
+=========
+
+:math:`n`-dimensional splines.
+
+.. toctree::
+   :maxdepth: 1
+
+   auto_examples/index
+   auto_benchmarks/index
+   api

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/examples/1d-interp.py
+++ b/examples/1d-interp.py
@@ -1,3 +1,9 @@
+"""
+===========================
+1-Dimensional Interpolation
+===========================
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import interpolate

--- a/examples/1d-lsq.py
+++ b/examples/1d-lsq.py
@@ -1,3 +1,9 @@
+"""
+===============================
+1-Dimensional Least Squares Fit
+===============================
+"""
+
 import ndsplines
 import matplotlib.pyplot as plt
 import numpy as np
@@ -5,7 +11,6 @@ from scipy import interpolate
 
 x = np.linspace(-3, 3, 50)
 y = np.exp(-x**2) + 0.1 * np.random.randn(50)
-
 
 t = [-1, 0, 1]
 k = 3
@@ -19,7 +24,7 @@ ispl = interpolate.make_lsq_spline(x, y, t, k)
 xs = np.linspace(-3, 3, 100)
 plt.figure()
 plt.plot(x, y, 'o', ms=5)
-plt.plot(xs, ndspl(xs), label='LSQ ND spline')
+plt.plot(xs, ndspl(xs).squeeze(), label='LSQ ND spline')
 plt.plot(xs, ispl(xs), '--', label='LSQ scipy.interpolate spline')
 plt.legend(loc='best')
 plt.show()

--- a/examples/2d-interp.py
+++ b/examples/2d-interp.py
@@ -1,3 +1,9 @@
+"""
+===========================
+2-Dimensional Interpolation
+===========================
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import interpolate

--- a/examples/2d-lsq.py
+++ b/examples/2d-lsq.py
@@ -1,3 +1,9 @@
+"""
+===============================
+2-Dimensional Least Squares Fit
+===============================
+"""
+
 import ndsplines 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,0 +1,6 @@
+========
+Examples
+========
+
+Here are some complete examples to demonstrate usage of ndsplines. Click on an
+example for details.

--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -30,18 +30,17 @@ bc_map =  {clamped: "clamped", pinned: "natural", extrap: None, periodic: None}
 
 
 class BSplineNDInterpolator(object):
+    """
+    Parameters
+    ----------
+    knots : list of ndarrays,
+        shapes=[n_1+orders[i-1]+1, ..., n_ndim+orders[-1]+1], dtype=np.float_
+    coefficients : ndarray, shape=(mdim, n_1, n_2, ..., n_ndim), dtype=np.float_
+    orders : ndarray, shape=(ndim,), dtype=np.int_
+    periodic : ndarray, shape=(ndim,), dtype=np.bool_
+    extrapolate : ndarray, shape=(ndim,2), dtype=np.bool_
+    """
     def __init__(self, knots, coefficients, orders, periodic=False, extrapolate=True):
-        """
-        Parameters
-        ----------
-        knots : list of ndarrays, 
-            shapes=[n_1+orders[i-1]+1, ..., n_ndim+orders[-1]+1], dtype=np.float_
-        coefficients : ndarray, shape=(mdim, n_1, n_2, ..., n_ndim), dtype=np.float_
-        orders : ndarray, shape=(ndim,), dtype=np.int_
-        periodic : ndarray, shape=(ndim,), dtype=np.bool_
-        extrapolate : ndarray, shape=(ndim,2), dtype=np.bool_
-            
-        """
         self.knots = knots
         self.coefficients = coefficients
         self.ndim = len(knots) # dimension of knots

--- a/readme.rst
+++ b/readme.rst
@@ -175,3 +175,9 @@ Now build the ``_bspl`` module::
 Now you can install::
 
     $ pip install -e .
+
+Build the docs::
+
+    $ pip install -e .[docs]
+    $ cd docs
+    $ make html

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setup(
     install_requires=['Cython', 'numpy', 'scipy'],
     extras_require={
         'examples': ['matplotlib'],
+        'docs': ['sphinx'],
     },
 )


### PR DESCRIPTION
So far, the following is included:

- examples gallery with plots rendered
- benchmarks gallery
- minimalist API reference

If we intend to expand on the docstrings (e.g. include some example usage), it may be worthwhile to use [autosummary](http://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html) with a separate page for each function/class. sphinx-gallery can also generate a per-function/class gallery, which could be cool too ([example](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html#examples-using-sklearn-cluster-dbscan)).

I disabled explicit garbage collection in the benchmark script or now because it was super annoying waiting for that to run each time I needed to clean and rebuild.

I'm not a huge fan of the alabaster theme, but right now the only extra dependency is sphinx.