### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,64 @@
+Copyright (c) 2019, Benjamin Margolis and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+ndsplines includes modified source code from the SciPy library. These are
+listed below with their original license:
+
+Files: _bspl.pyx, _bspl.h
+License: 3-clause BSD
+  Copyright (c) 2001, 2002 Enthought, Inc.
+  All rights reserved.
+
+  Copyright (c) 2003-2019 SciPy Developers.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    a. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+    b. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    c. Neither the name of Enthought nor the names of the SciPy Developers
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+  OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include readme.rst
+include LICENSE

--- a/ndsplines/_bspl.h
+++ b/ndsplines/_bspl.h
@@ -1,5 +1,8 @@
 /*
  * B-spline evaluation routine.
+ *
+ * This file contains code from SciPy which has been adapted to suit the needs
+ * of ndsplines (scipy/interpolate/src/__fitpack.h). See LICENSE for details.
  */
 
 static NPY_INLINE void

--- a/ndsplines/_bspl.pyx
+++ b/ndsplines/_bspl.pyx
@@ -3,6 +3,9 @@ Routines for evaluating and manipulating B-splines.
 
 """
 
+# This file contains code from SciPy which has been adapted to suit the needs
+# of ndsplines (scipy/interpolate/_bspl.pyx). See LICENSE for details.
+
 from __future__ import absolute_import
 
 import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     author="Benjamin Margolis",
     packages=["ndsplines"],
     ext_modules=cythonize(extensions),
+    license='BSD',
     # TODO: figure out how this is supposed to work
     # https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords
     setup_requires=['Cython', 'numpy'],


### PR DESCRIPTION
Fixes #10. I ended up adding the SciPy license to the main LICENSE file and noting in the files themselves that they originated from SciPy, just because it's a little annoying to have the full license text in each file. I can't really find a common/best practice -- different projects seem to do their own thing and this seems pretty clean to me. For BSD, making it clear where the files came from and providing the original license should be sufficient regardless of how exactly you do so.